### PR TITLE
fixed diagram element connections

### DIFF
--- a/diagramflow/frontend/src/App.tsx
+++ b/diagramflow/frontend/src/App.tsx
@@ -37,8 +37,8 @@ export function AppWithProviders() {
                         <Route path="/login" element={<LoginPage/>}/>
                         <Route path="/register" element={<RegisterPage/>}/>
                         {/*For development purposes only uncommnet these two lines to access pages without a login */}
-                        {/*<Route path="/dashboard" element={<DashboardPage/>}></Route>*/}
-                        {/*<Route path="/diagrampage" element={<DiagramPage/>}></Route>*/}
+                        <Route path="/dashboard" element={<DashboardPage/>}></Route>
+                        <Route path="/diagrampage" element={<DiagramPage/>}></Route>
                         <Route
                             path="/dashboard"
                             element={

--- a/diagramflow/frontend/src/components/DiagramPage/Canvas/ConnectionElement.tsx
+++ b/diagramflow/frontend/src/components/DiagramPage/Canvas/ConnectionElement.tsx
@@ -1,13 +1,17 @@
 import Konva from "konva";
-import {Circle} from "react-konva";
-import {connection, lineTypes} from "../connection.ts";
-import {ExtendedDiagramElementProps} from "./Canvas.tsx";
-import {useCallback, useEffect, useState} from "react";
-import {KonvaEventObject} from "konva/lib/Node";
+import { Circle } from "react-konva";
+import { connection, lineTypes } from "../connection.ts";
+import { ExtendedDiagramElementProps } from "./Canvas.tsx";
+import { useCallback, useEffect, useState } from "react";
+import { KonvaEventObject } from "konva/lib/Node";
 import JaggedLine from "./JaggedLine.tsx";
 import StraightLine from "./StraightLine.tsx";
 
-const ConnectionElement = ({element, diagramElements, handleKonvaContextMenu}: {
+const ConnectionElement = ({
+  element,
+  diagramElements,
+  handleKonvaContextMenu,
+}: {
   element: connection,
   diagramElements: ExtendedDiagramElementProps[],
   handleKonvaContextMenu: (e: KonvaEventObject<PointerEvent>, id: string) => void;
@@ -18,41 +22,40 @@ const ConnectionElement = ({element, diagramElements, handleKonvaContextMenu}: {
   const [endX, setEndX] = useState(x2);
   const [endY, setEndY] = useState(y2);
   const collisionRadius = 30;
-  
+
+  const getCenterOfNearestWall = (diagramElement: ExtendedDiagramElementProps, x: number, y: number) => {
+    const { posX, posY, width, height } = diagramElement;
+    const walls = [
+      { wall: 'left',    x: posX,         y: posY + height / 2, distance: Math.hypot(x - posX, y - (posY + height / 2)) },
+      { wall: 'right',   x: posX + width, y: posY + height / 2, distance: Math.hypot(x - (posX + width), y - (posY + height / 2)) },
+      { wall: 'top',     x: posX + width / 2, y: posY, distance: Math.hypot(x - (posX + width / 2), y - posY) },
+      { wall: 'bottom',  x: posX + width / 2, y: posY + height, distance: Math.hypot(x - (posX + width / 2), y - (posY + height)) },
+    ];
+    return walls.reduce((a, b) => (a.distance < b.distance ? a : b));
+  };
+
   const updatePosition = (e: Konva.KonvaEventObject<DragEvent>, point: string) => {
-    const {clientX, clientY} = e.evt;
+    const { clientX, clientY } = e.evt;
     const canvasRect = e.target.getStage()?.container().getBoundingClientRect();
     let newX = clientX - (canvasRect?.left || 0);
     let newY = clientY - (canvasRect?.top || 0);
-    
+
     let snappedElementId = null;
     let snappedWall = null;
-    
+
     for (const diagramElement of diagramElements) {
-      const {posX, posY, width, height} = diagramElement;
-      
-      if (
-        newX >= posX &&
-        newX <= posX + width &&
-        newY >= posY &&
-        newY <= posY + height
-      ) {
-        const distances = [
-          {wall: 'left', x: posX, y: posY + height / 2, distance: Math.abs(newX - posX)},
-          {wall: 'right', x: posX + width, y: posY + height / 2, distance: Math.abs(newX - (posX + width))},
-          {wall: 'top', x: posX + width / 2, y: posY, distance: Math.abs(newY - posY)},
-          {wall: 'bottom', x: posX + width / 2, y: posY + height, distance: Math.abs(newY - (posY + height))},
-        ];
-        
-        const closest = distances.reduce((a, b) => (a.distance < b.distance ? a : b));
-        newX = closest.x;
-        newY = closest.y;
+      const { posX, posY, width, height } = diagramElement;
+
+      if (newX >= posX && newX <= posX + width && newY >= posY && newY <= posY + height) {
+        const wall = getCenterOfNearestWall(diagramElement, newX, newY);
+        newX = wall.x;
+        newY = wall.y;
         snappedElementId = diagramElement.id;
-        snappedWall = closest.wall;
+        snappedWall = wall.wall;
         break;
       }
     }
-    
+
     if (point === 'start') {
       element.setStart(null, null);
       const distance = Math.hypot(newX - endX, newY - endY);
@@ -63,6 +66,20 @@ const ConnectionElement = ({element, diagramElements, handleKonvaContextMenu}: {
         const t = collisionRadius * 2 / distance;
         setStartX(endX + t * (newX - endX));
         setStartY(endY + t * (newY - endY));
+      }
+      if (snappedElementId && snappedWall) {
+        element.setStart(snappedElementId, snappedWall);
+      }
+
+      const endSnappedId = element.getEndSnappedElementId();
+      if (endSnappedId) {
+        const endElement = diagramElements.find(el => el.id === endSnappedId);
+        if (endElement) {
+          const wall = getCenterOfNearestWall(endElement, startX, startY);
+          setEndX(wall.x);
+          setEndY(wall.y);
+          element.setEnd(endSnappedId, wall.wall);
+        }
       }
     } else {
       element.setEnd(null, null);
@@ -75,88 +92,68 @@ const ConnectionElement = ({element, diagramElements, handleKonvaContextMenu}: {
         setEndX(startX + t * (newX - startX));
         setEndY(startY + t * (newY - startY));
       }
-    }
-    
-    if (snappedElementId && snappedWall) {
-      if (point === 'start') {
-        element.setStart(snappedElementId, snappedWall);
-      } else {
+      if (snappedElementId && snappedWall) {
         element.setEnd(snappedElementId, snappedWall);
+      }
+
+      const startSnappedId = element.getStartSnappedElementId();
+      if (startSnappedId) {
+        const startElement = diagramElements.find(el => el.id === startSnappedId);
+        if (startElement) {
+          const wall = getCenterOfNearestWall(startElement, endX, endY);
+          setStartX(wall.x);
+          setStartY(wall.y);
+          element.setStart(startSnappedId, wall.wall);
+        }
       }
     }
   };
-  
-  // TODO : While moving one end of the connection, the other end should snap to the nearest wall
-  const updateSnappedElementPosition = useCallback((snappedElementId: string | null, setX: (value: number) => void, setY: (value: number) => void, snapPosition: string | null) => {
-    if (!snappedElementId) {
-      return;
-    }
-    
+
+  const updateSnappedElementPosition = useCallback((
+    snappedElementId: string | null,
+    setX: (value: number) => void,
+    setY: (value: number) => void,
+    oppositeX: number,
+    oppositeY: number
+  ) => {
+    if (!snappedElementId) return;
+
     const diagramElement = diagramElements.find(el => el.id === snappedElementId);
-    if (!diagramElement) {
-      return;
+    if (!diagramElement) return;
+
+    const wall = getCenterOfNearestWall(diagramElement, oppositeX, oppositeY);
+    setX(wall.x);
+    setY(wall.y);
+
+    if (setX === setStartX) {
+      element.setStart(snappedElementId, wall.wall);
+    } else {
+      element.setEnd(snappedElementId, wall.wall);
     }
-    
-    let offsetX = 0, offsetY = 0;
-    switch (snapPosition) {
-      case 'left':
-        offsetY = diagramElement.height / 2;
-        break;
-      case 'right':
-        offsetX = diagramElement.width;
-        offsetY = diagramElement.height / 2;
-        break;
-      case 'top':
-        offsetX = diagramElement.width / 2;
-        break;
-      case 'bottom':
-        offsetX = diagramElement.width / 2;
-        offsetY = diagramElement.height;
-        break;
-    }
-    setX(diagramElement.posX + offsetX);
-    setY(diagramElement.posY + offsetY);
   }, [diagramElements]);
-  
+
   useEffect(() => {
-    updateSnappedElementPosition(element.getStartSnappedElementId(), setStartX, setStartY, element.getStartPosition());
-  }, [diagramElements, element, updateSnappedElementPosition]);
-  
+    updateSnappedElementPosition(element.getStartSnappedElementId(), setStartX, setStartY, endX, endY);
+  }, [diagramElements, element, endX, endY, updateSnappedElementPosition]);
+
   useEffect(() => {
-    updateSnappedElementPosition(element.getEndSnappedElementId(), setEndX, setEndY, element.getEndPosition());
-  }, [diagramElements, element, updateSnappedElementPosition]);
-  
+    updateSnappedElementPosition(element.getEndSnappedElementId(), setEndX, setEndY, startX, startY);
+  }, [diagramElements, element, startX, startY, updateSnappedElementPosition]);
+
   return (
     <>
-      {/*The visuals*/}
-      <Circle
-        x={startX}
-        y={startY}
-        radius={3}
-        fill="black"
-      />
-      <Circle
-        x={endX}
-        y={endY}
-        radius={3}
-        fill="black"
-      />
-      {
-        element.lineType == lineTypes.straight ?
+      <Circle x={startX} y={startY} radius={3} fill="black" />
+      <Circle x={endX} y={endY} radius={3} fill="black" />
+      {element.lineType == lineTypes.straight ? (
         <StraightLine
           coords={[startX, startY, endX, endY]}
           element={element}
           collisionRadius={collisionRadius}
           handleKonvaContextMenu={handleKonvaContextMenu}
         />
-          :
-        <JaggedLine
-          coords={[startX, startY, endX, endY]}
-          element={element}
-        />
-      }
-      
-      {/*The collision detection*/}
+      ) : (
+        <JaggedLine coords={[startX, startY, endX, endY]} element={element} />
+      )}
       <Circle
         x={startX}
         y={startY}


### PR DESCRIPTION
This pull request introduces several changes to the `diagramflow` frontend, focusing on enabling development routes, improving snapping logic for connection elements, and refactoring the `ConnectionElement` component for better maintainability and functionality. Below is a summary of the most important changes:

### Development Routes
* Enabled the `/dashboard` and `/diagrampage` routes in `App.tsx` for development purposes by uncommenting the relevant lines.

### Snapping Logic Enhancements
* Introduced a new helper function, `getCenterOfNearestWall`, to calculate the closest wall of a diagram element based on a given point. This centralizes and simplifies snapping logic.
* Updated the snapping behavior in `updatePosition` to use the new helper function, improving accuracy and readability.

### Refactoring for Maintainability
* Refactored the `updateSnappedElementPosition` function to use the `getCenterOfNearestWall` helper, reducing redundant code and improving clarity.
* Simplified the JSX structure in the `ConnectionElement` component by condensing conditional rendering for `StraightLine` and `JaggedLine` components.